### PR TITLE
Malt0 on intersection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dev
+Changement de la définition de la zone où est calculée MALT0:
+- masquage du MNx à l'aide de la carte de classe dans MALT0 intrinsic
+- comparaison des MNx sur l'intersection des zones hors no-data (pour exclure les pixels en bord de aillage : inclus dans la carte de classe mais hors du maillage utilisé pour le MNx)
+
 # 0.6.0
 - ajout d'une 4e métrique : MOBJ0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # dev
-Changement de la définition de la zone où est calculée MALT0:
-- masquage du MNx à l'aide de la carte de classe dans MALT0 intrinsic
-- comparaison des MNx sur l'intersection des zones hors no-data (pour exclure les pixels en bord de aillage : inclus dans la carte de classe mais hors du maillage utilisé pour le MNx)
+- Changement de la définition de la zone où est calculée MALT0:
+  - masquage du MNx à l'aide de la carte de classe dans MALT0 intrinsic
+  - comparaison des MNx sur l'intersection des zones hors no-data (pour exclure les pixels en bord de maillage :
+  inclus dans la carte de classe mais hors du maillage utilisé pour le MNx)
+- Disparition de la distinction entre calcul de la référence et l'autre nuage de points (était nécessaire uniquement
+pour le calcul de MALT0)
 
 # 0.6.0
 - ajout d'une 4e métrique : MOBJ0

--- a/coclico/main.py
+++ b/coclico/main.py
@@ -148,7 +148,7 @@ def create_compare_project(
 
                 out_ref_metric = out_ref / metric_name / "intrinsic"
                 out_ref_metric.mkdir(parents=True, exist_ok=True)
-                metric_jobs = metric.create_metric_intrinsic_jobs("ref", tile_names, ref, out_ref_metric, is_ref=True)
+                metric_jobs = metric.create_metric_intrinsic_jobs("ref", tile_names, ref, out_ref_metric)
                 add_dependency_to_jobs(metric_jobs, unlock_job)
 
                 ref_jobs[metric_name] = metric_jobs
@@ -176,9 +176,7 @@ def create_compare_project(
                     out_ci_metric = out_ci / metric_name / "intrinsic"
 
                     out_ci_metric.mkdir(parents=True, exist_ok=True)
-                    ci_intrinsic_jobs = metric.create_metric_intrinsic_jobs(
-                        ci.name, tile_names, ci, out_ci_metric, is_ref=False
-                    )
+                    ci_intrinsic_jobs = metric.create_metric_intrinsic_jobs(ci.name, tile_names, ci, out_ci_metric)
                     add_dependency_to_jobs(ci_intrinsic_jobs, unlock_job)
 
                     out_ci_to_ref_metric = out_ci / metric_name / "to_ref"

--- a/coclico/malt0/malt0.py
+++ b/coclico/malt0/malt0.py
@@ -22,7 +22,7 @@ class MALT0(Metric):
     pixel_size = 0.5
     metric_name = "malt0"
 
-    def create_metric_intrinsic_one_job(self, name: str, input: Path, output: Path, is_ref: bool):
+    def create_metric_intrinsic_one_job(self, name: str, input: Path, output: Path):
         job_name = f"{self.metric_name}_intrinsic_{name}_{input.stem}"
         command = f"""
 docker run -t --rm --userns=host --shm-size=2gb

--- a/coclico/malt0/malt0.py
+++ b/coclico/malt0/malt0.py
@@ -24,14 +24,6 @@ class MALT0(Metric):
 
     def create_metric_intrinsic_one_job(self, name: str, input: Path, output: Path, is_ref: bool):
         job_name = f"{self.metric_name}_intrinsic_{name}_{input.stem}"
-        occupancy_map_arg = ""
-        mnx_out = output / "mnx"
-        mnx_out.mkdir(exist_ok=True, parents=True)
-        if is_ref:
-            occ_out = output / "occupancy"
-            occ_out.mkdir(exist_ok=True, parents=True)
-            occupancy_map_arg = f"--output-occupancy-file /output/occupancy/{input.stem}.tif"
-
         command = f"""
 docker run -t --rm --userns=host --shm-size=2gb
 -v {self.store.to_unix(input)}:/input
@@ -40,8 +32,7 @@ docker run -t --rm --userns=host --shm-size=2gb
 ignimagelidar/coclico:{__version__}
 python -m coclico.malt0.malt0_intrinsic
 --input-file /input
---output-mnx-file /output/mnx/{input.stem}.tif
-{occupancy_map_arg}
+--output-mnx-file /output/{input.stem}.tif
 --config-file /config/{self.config_file.name}
 --pixel-size {self.pixel_size}
 
@@ -56,16 +47,14 @@ python -m coclico.malt0.malt0_intrinsic
         job_name = f"{self.metric_name}_{name}_relative_to_ref"
         command = f"""
 docker run -t --rm --userns=host --shm-size=2gb
--v {self.store.to_unix(out_c1) / "mnx"}:/input
--v {self.store.to_unix(out_ref) / "mnx"}:/ref
--v {self.store.to_unix(out_ref) / "occupancy"}:/occupancy
+-v {self.store.to_unix(out_c1)}:/input
+-v {self.store.to_unix(out_ref)}:/ref
 -v {self.store.to_unix(output)}:/output
 -v {self.store.to_unix(self.config_file.parent)}:/config
 ignimagelidar/coclico:{__version__}
 python -m coclico.malt0.malt0_relative
 --input-dir /input
 --ref-dir /ref
---occupancy-dir /occupancy
 --output-csv-tile /output/result_tile.csv
 --output-csv /output/result.csv
 --config-file /config/{self.config_file.name}

--- a/coclico/metrics/metric.py
+++ b/coclico/metrics/metric.py
@@ -21,7 +21,7 @@ class Metric:
         self.config_file = config_file
 
     def create_metric_intrinsic_jobs(
-        self, name: str, tile_names: List[str], input_path: Path, out_path: Path, is_ref: bool
+        self, name: str, tile_names: List[str], input_path: Path, out_path: Path
     ) -> List[Job]:
         """Create jobs for a single classified point cloud folder (eg. ref, c1 or c2)
         These jobs are aimed to compute intermediate results on the input las that will be used in
@@ -31,21 +31,18 @@ class Metric:
             tile_names (List[str]): list of the filenames of the tiles on which to calculate the result
             input_path (Path): input folder path (path to the results of the classification)
             out_path (Path): path for the intermediate results to be saved
-            is_ref (bool): flag that says if the input classification folder is the reference folder
         Returns:
             List[Job]: List of GPAO jobs to create
         """
-        return [self.create_metric_intrinsic_one_job(name, input_path / f, out_path, is_ref) for f in tile_names]
+        return [self.create_metric_intrinsic_one_job(name, input_path / f, out_path) for f in tile_names]
 
-    def create_metric_intrinsic_one_job(self, name: str, input: Path, output: Path, is_ref: bool) -> Job:
+    def create_metric_intrinsic_one_job(self, name: str, input: Path, output: Path) -> Job:
         """Create a job to compute the intrinsic metric for a single point cloud file.
 
         Args:
             name (str): classification name (used for job name creation)
             input (Path): full path of the input tile
             output (Path): output folder for the result
-            is_ref (bool):  flag that says if the input classification folder is the reference folder (in case it has
-            to be treated differently)
 
         Raises:
             NotImplementedError: should be implemented in children classes

--- a/coclico/mobj0/mobj0.py
+++ b/coclico/mobj0/mobj0.py
@@ -23,7 +23,7 @@ class MOBJ0(Metric):
     kernel = 3  # parameter for morphological operations on rasters
     tolerance_shp = 0.05  # parameter for simplification on geometries of the shapefile
 
-    def create_metric_intrinsic_one_job(self, name: str, input: Path, output: Path, is_ref: bool):
+    def create_metric_intrinsic_one_job(self, name: str, input: Path, output: Path):
         job_name = f"{self.metric_name}_intrinsic_{name}_{input.stem}"
         command = f"""
 docker run -t --rm --userns=host --shm-size=2gb

--- a/coclico/mpap0/mpap0.py
+++ b/coclico/mpap0/mpap0.py
@@ -19,7 +19,7 @@ class MPAP0(Metric):
 
     metric_name = "mpap0"
 
-    def create_metric_intrinsic_one_job(self, name: str, input: Path, output: Path, is_ref: bool = False):
+    def create_metric_intrinsic_one_job(self, name: str, input: Path, output: Path):
         job_name = f"{self.metric_name}_intrinsic_{name}_{input.stem}"
 
         command = f"""

--- a/coclico/mpla0/mpla0.py
+++ b/coclico/mpla0/mpla0.py
@@ -23,7 +23,7 @@ class MPLA0(Metric):
     map_pixel_size = 0.5
     metric_name = "mpla0"
 
-    def create_metric_intrinsic_one_job(self, name: str, input: Path, output: Path, is_ref: bool = False):
+    def create_metric_intrinsic_one_job(self, name: str, input: Path, output: Path):
         job_name = f"{self.metric_name}_intrinsic_{name}_{input.stem}"
 
         command = f"""

--- a/doc/malt0.md
+++ b/doc/malt0.md
@@ -15,23 +15,25 @@ des nuages filtrés pour ne contenir que la classe demandée.
 
 ### Métrique intrinsèque (calculée indépendemment pour le nuage de référence et le nuage classé à comparer) :
 
-Calcul du MNx (modèle numérique de surface calculé à partir d'une classe donnée) et d'une carte
-d'occupation (carte binaire à la même résolution que le MNx qui indique si le pixel contient au moins
-un point de la classe représentée, cf [MPLA0](./mpla0.md)) pour chaque classe.
+Calcul du MNx (modèle numérique de surface calculé à partir d'une classe donnée) pour chaque classe.
 
 Le MNx est calculé par :
 - génération d'une triangulation de Delaunay 2d des points de la classe
 - interpolation des valeurs sur un raster à la taille de pixel désirée (pdal faceraster filter)
+- masquage à l'aide d'une carte d'occupation (carte binaire à la même résolution que le MNx qui indique si le pixel contient au moins un point de la classe représentée, cf [MPLA0](./mpla0.md)). L'idée est d'avoir un MNx qui n'a de valeurs que là où il est pertinent, et la valeur no-data ailleurs.
 
 Résultat :
 - pour chaque nuage (référence ou à comparer), un fichier tif contenant une couche par
-classe qui représente le MNx de la classe donnée
-- pour chaque nuage de référence, un fichier tif contenant une couche par classe qui représente la carte d'occupation de la classe donnée
+classe qui représente le MNx de la classe donnée là où il est pertinent
 
 ### Métrique relative (calculée à partir des fichiers intermédiaires en sortie de métrique intrinsèque)
 
-Pour chaque classe, comparer les valeurs des cartes de MNx (`height_maps`) entre la référence et le nuage à comparer,
-uniquement sur les pixels où le nuage de référence a des points de cette classe (valeurs positives de la carte d'occupation).
+Pour chaque classe, comparer les valeurs des cartes de MNx (`height_maps`) entre la référence et le
+nuage à comparer,uniquement sur les pixels où les MNx sont définis dans les deux cartes.
+
+ATTENTION : si les zones de définition du MNx sont très différentes, cette métrique peut être biaisée,
+il est donc suggéré d'observer les résultats de [MPLA0](./mpla0.md) avec les résultats de MALT0 pour
+visualiser sur quelle proportion du nuage MALT0 est calculée
 
 Les valeurs de sortie (dans un fichier csv) sont pour chaque classe :
 - `mean_diff` : différence moyenne en z entre les MNx pour chaque pixel (0 si aucun pixel dans la référence)


### PR DESCRIPTION
Changement de méthode de choix des points sur lesquels on calcule le MNx dans MALT0 : au lieu d'utiliser la carte de classe de la référence, on utilise la carte de classe de chaque nuage pour forcer des points en no-data puis on calcule la métrique uniquement sur les points qui ont une valeur