### PR TITLE
Fix mobj0 topo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/ambv/black
-    rev: 23.9.1
+    rev: 24.2.0
     hooks:
       - id: black
         language_version: python3.10
@@ -13,7 +13,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/ambv/black
-    rev: 24.2.0
+    rev: 24.3.0
     hooks:
       - id: black
         language_version: python3.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dev
+- MOBJ0 : Utilisation de la 4-connexité au lieu de 8-connexité pour la génération des formes à partir de la carte
+d'occupation (pour éviter la création de formes non-valides, et c'est plus cohérent avec les opérations morphologiques
+utilisées sur la carte de classe).
+
 # 1.0.0
 
 Première version utilisable de Coclico, avec 4 métriques implémentées : MPAP0, MPLA0, MALT0, MOBJ0

--- a/coclico/mobj0/mobj0_intrinsic.py
+++ b/coclico/mobj0/mobj0_intrinsic.py
@@ -36,7 +36,7 @@ def vectorize_occupancy_map(binary_maps: np.ndarray, crs: str, x_min: float, y_m
     for ii, map_layer in enumerate(binary_maps):
         shapes_layer = rasterio_shapes(
             map_layer,
-            connectivity=8,
+            connectivity=4,
             transform=rasterio.transform.from_origin(
                 x_min - pixel_size / 2, y_max + pixel_size / 2, pixel_size, pixel_size
             ),

--- a/test/mobj0/test_mobj0_intrinsic.py
+++ b/test/mobj0/test_mobj0_intrinsic.py
@@ -61,6 +61,16 @@ def test_compute_metric_intrinsic(ensure_test1_data):
     assert len(set(gdf["layer"])) == nb_layers - 1  # There should be rows for every class, except one (class 9)
 
 
+def test_vectorize_occupancy_map():
+    # Create map with 1 layer 3 pixels that have 8-connexity but not 4 connexity to emulate a map that generates
+    # non-valid shape cases
+    occ_map = np.eye(3, dtype=np.uint8)
+    occ_maps = np.expand_dims(occ_map, axis=0)
+
+    gdf = mobj0_intrinsic.vectorize_occupancy_map(occ_maps, crs="EPSG:2154", x_min=10, y_max=10, pixel_size=1)
+    assert gdf.is_valid.all()  # This assertion is false if we use 8-connectivity
+
+
 def test_run_main(ensure_test1_data):
     pixel_size = 0.5
     kernel = 3


### PR DESCRIPTION
in MOBJ0, Use 4-connexity instead of 8-connexity to prevent creating non-valid shapes
It is also more consistent with the morphological operations run on the occupancy map